### PR TITLE
Allow changing Bedrock model via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 | `RECALLBOT_POSTED_URLS_TABLE_NAME` | いいえ | 投稿済み URL を保存する DynamoDB テーブル名。既定値: `recallbot_dev_posted_urls` |
 | `RECALLBOT_DOCUMENT_INTELLIGENCE_ENDPOINT` | いいえ | Azure Document Intelligence のエンドポイント URL。既定値: `https://japaneast.api.cognitive.microsoft.com/` |
 | `RECALLBOT_DOCUMENT_INTELLIGENCE_API_KEY` | はい | Document Intelligence の API キー |
-| `RECALLBOT_BEDROCK_MODEL_ID` | いいえ | ask-ai-to-choose-tool で使用する Bedrock モデル ID。既定値: `us.anthropic.claude-3-haiku-20240307-v1:0` |
-| `RECALLBOT_BEDROCK_REGION` | いいえ | ask-ai-to-choose-tool で使用する Bedrock リージョン。既定値: `us-east-2` |
+| `RECALLBOT_BEDROCK_MODEL_ID` | いいえ | Bedrock の Inference Profile。既定値: `us.anthropic.claude-3-haiku-20240307-v1:0` |
+| `RECALLBOT_BEDROCK_REGION` | いいえ | Bedrock のリージョン。既定値: `us-east-2` |
 | `RECALLBOT_MASTODON_BASE_URL` | いいえ | 投稿先 Pleroma/Mastodon サーバーの URL。既定値: `https://xxx.azyobuzi.net/` |
 | `RECALLBOT_MASTODON_ACCESS_TOKEN` | はい | 投稿に使用するアクセストークン |
 | `RECALLBOT_ERROR_TOPIC_ARN` | いいえ | エラー通知に利用する SNS トピック ARN |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 | `RECALLBOT_POSTED_URLS_TABLE_NAME` | いいえ | 投稿済み URL を保存する DynamoDB テーブル名。既定値: `recallbot_dev_posted_urls` |
 | `RECALLBOT_DOCUMENT_INTELLIGENCE_ENDPOINT` | いいえ | Azure Document Intelligence のエンドポイント URL。既定値: `https://japaneast.api.cognitive.microsoft.com/` |
 | `RECALLBOT_DOCUMENT_INTELLIGENCE_API_KEY` | はい | Document Intelligence の API キー |
+| `RECALLBOT_BEDROCK_MODEL_ID` | いいえ | ask-ai-to-choose-tool で使用する Bedrock モデル ID。既定値: `us.anthropic.claude-3-haiku-20240307-v1:0` |
+| `RECALLBOT_BEDROCK_REGION` | いいえ | ask-ai-to-choose-tool で使用する Bedrock リージョン。既定値: `us-east-2` |
 | `RECALLBOT_MASTODON_BASE_URL` | いいえ | 投稿先 Pleroma/Mastodon サーバーの URL。既定値: `https://xxx.azyobuzi.net/` |
 | `RECALLBOT_MASTODON_ACCESS_TOKEN` | はい | 投稿に使用するアクセストークン |
 | `RECALLBOT_ERROR_TOPIC_ARN` | いいえ | エラー通知に利用する SNS トピック ARN |

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -11,6 +11,12 @@ const environmentVariableDefinitions = {
     defaultValue: "https://japaneast.api.cognitive.microsoft.com/",
   },
   RECALLBOT_DOCUMENT_INTELLIGENCE_API_KEY: { required: true },
+  RECALLBOT_BEDROCK_MODEL_ID: {
+    defaultValue: "us.anthropic.claude-3-haiku-20240307-v1:0",
+  },
+  RECALLBOT_BEDROCK_REGION: {
+    defaultValue: "us-east-2",
+  },
   RECALLBOT_MASTODON_BASE_URL: { defaultValue: "https://xxx.azyobuzi.net/" },
   RECALLBOT_MASTODON_ACCESS_TOKEN: { required: true },
   RECALLBOT_ERROR_TOPIC_ARN: { required: false },

--- a/lib/infrastructures/ask-ai-to-choose-tool.ts
+++ b/lib/infrastructures/ask-ai-to-choose-tool.ts
@@ -7,6 +7,7 @@ import {
   type ToolConfiguration,
   type ToolSpecification,
 } from "@aws-sdk/client-bedrock-runtime";
+import { getEnv } from "../env.ts";
 import type { ServiceFactoryWithDefault } from "../types.ts";
 
 export type AskAIToChooseTool = (
@@ -85,11 +86,13 @@ export const askAIToChooseTool: AskAIToChooseToolFactory =
 
 askAIToChooseTool.withDefaultDeps = () =>
   askAIToChooseTool({
-    bedrockRuntimeClient: new BedrockRuntimeClient({ region: "us-east-2" }),
+    bedrockRuntimeClient: new BedrockRuntimeClient({
+      region: getEnv("RECALLBOT_BEDROCK_REGION"),
+    }),
   });
 
 const commandBase = {
-  modelId: "us.anthropic.claude-3-haiku-20240307-v1:0",
+  modelId: getEnv("RECALLBOT_BEDROCK_MODEL_ID"),
   inferenceConfig: {
     maxTokens: 2048,
     temperature: 0,


### PR DESCRIPTION
## Summary
- allow selecting the model used for ask-ai-to-choose-tool via a new env var
- expose region setting via `RECALLBOT_BEDROCK_REGION`
- document the variables in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e25952ea88332b43e371f5d689287